### PR TITLE
Update to the latest transport-jms repo

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -227,7 +227,7 @@
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -279,13 +279,13 @@
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
                     </descriptors>
-                    <finalName>ballerina-jms-connector-${project.version}</finalName>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>ballerina-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.transport</groupId>
-            <artifactId>org.wso2.carbon.transport.jms</artifactId>
+            <groupId>org.wso2.transport.jms</groupId>
+            <artifactId>transport-jms</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
@@ -240,9 +240,9 @@
                                     <type>${project.packaging}</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wso2.carbon.transport</groupId>
-                                    <artifactId>org.wso2.carbon.transport.jms</artifactId>
-                                    <version>${carbon.transport.version}</version>
+                                    <groupId>org.wso2.transport.jms</groupId>
+                                    <artifactId>transport-jms</artifactId>
+                                    <version>${wso2.transport.jms.version}</version>
                                     <type>${project.packaging}</type>
                                 </artifactItem>
                                 <artifactItem>

--- a/component/src/main/java/org/ballerinalang/net/jms/Constants.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/Constants.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.net.jms;
 
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/component/src/main/java/org/ballerinalang/net/jms/JMSConnectorFutureListener.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/JMSConnectorFutureListener.java
@@ -22,7 +22,7 @@ import org.ballerinalang.connector.api.ConnectorFutureListener;
 import org.ballerinalang.model.values.BValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.transport.jms.callback.JMSCallback;
+import org.wso2.transport.jms.callback.JMSCallback;
 
 /**
  * {@code JMSConnectorFutureListener} is the responsible for acting on notifications received from Ballerina side.

--- a/component/src/main/java/org/ballerinalang/net/jms/JMSListenerImpl.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/JMSListenerImpl.java
@@ -22,8 +22,8 @@ import org.ballerinalang.connector.api.ConnectorFuture;
 import org.ballerinalang.connector.api.ConnectorFutureListener;
 import org.ballerinalang.connector.api.Executor;
 import org.ballerinalang.connector.api.Resource;
-import org.wso2.carbon.transport.jms.callback.JMSCallback;
-import org.wso2.carbon.transport.jms.contract.JMSListener;
+import org.wso2.transport.jms.callback.JMSCallback;
+import org.wso2.transport.jms.contract.JMSListener;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/component/src/main/java/org/ballerinalang/net/jms/JMSServerConnector.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/JMSServerConnector.java
@@ -24,10 +24,10 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.BallerinaServerConnector;
 import org.ballerinalang.connector.api.Service;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.carbon.transport.jms.contract.JMSListener;
-import org.wso2.carbon.transport.jms.exception.JMSConnectorException;
-import org.wso2.carbon.transport.jms.impl.JMSConnectorFactoryImpl;
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.contract.JMSListener;
+import org.wso2.transport.jms.exception.JMSConnectorException;
+import org.wso2.transport.jms.impl.JMSConnectorFactoryImpl;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +40,7 @@ import java.util.Map;
 @JavaSPIService("org.ballerinalang.connector.api.BallerinaServerConnector")
 public class JMSServerConnector implements BallerinaServerConnector {
 
-    private Map<String, org.wso2.carbon.transport.jms.contract.JMSServerConnector> connectorMap = new HashMap<>();
+    private Map<String, org.wso2.transport.jms.contract.JMSServerConnector> connectorMap = new HashMap<>();
 
     @Override
     public String getProtocolPackage() {
@@ -63,7 +63,7 @@ public class JMSServerConnector implements BallerinaServerConnector {
         try {
             // Create a new JMS Listener for this this JMS Service and include it in a new JMS Server Connector
             JMSListener jmsListener = new JMSListenerImpl(JMSUtils.extractJMSResource(service));
-            org.wso2.carbon.transport.jms.contract.JMSServerConnector serverConnector = new JMSConnectorFactoryImpl()
+            org.wso2.transport.jms.contract.JMSServerConnector serverConnector = new JMSConnectorFactoryImpl()
                     .createServerConnector(serviceId, configParams, jmsListener);
 
             connectorMap.put(serviceId, serverConnector);
@@ -78,7 +78,7 @@ public class JMSServerConnector implements BallerinaServerConnector {
     public void serviceUnregistered(Service service) throws BallerinaConnectorException {
         String serviceId = service.getName();
         try {
-            org.wso2.carbon.transport.jms.contract.JMSServerConnector serverConnector = connectorMap.get(serviceId);
+            org.wso2.transport.jms.contract.JMSServerConnector serverConnector = connectorMap.get(serviceId);
             if (null != serverConnector) {
                 serverConnector.stop();
             }

--- a/component/src/main/java/org/ballerinalang/net/jms/JMSTransactionContext.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/JMSTransactionContext.java
@@ -21,10 +21,10 @@ import org.ballerinalang.bre.BallerinaTransactionContext;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.transport.jms.contract.JMSClientConnector;
-import org.wso2.carbon.transport.jms.exception.JMSConnectorException;
-import org.wso2.carbon.transport.jms.sender.wrappers.SessionWrapper;
-import org.wso2.carbon.transport.jms.sender.wrappers.XASessionWrapper;
+import org.wso2.transport.jms.contract.JMSClientConnector;
+import org.wso2.transport.jms.exception.JMSConnectorException;
+import org.wso2.transport.jms.sender.wrappers.SessionWrapper;
+import org.wso2.transport.jms.sender.wrappers.XASessionWrapper;
 
 import javax.jms.JMSException;
 import javax.transaction.xa.XAResource;

--- a/component/src/main/java/org/ballerinalang/net/jms/JMSUtils.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/JMSUtils.java
@@ -26,7 +26,7 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.carbon.kernel.utils.StringUtils;
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.HashMap;
 import java.util.Iterator;

--- a/component/src/main/java/org/ballerinalang/net/jms/actions/Send.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/actions/Send.java
@@ -36,11 +36,11 @@ import org.ballerinalang.util.DistributedTxManagerProvider;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.transport.jms.contract.JMSClientConnector;
-import org.wso2.carbon.transport.jms.exception.JMSConnectorException;
-import org.wso2.carbon.transport.jms.impl.JMSConnectorFactoryImpl;
-import org.wso2.carbon.transport.jms.sender.wrappers.SessionWrapper;
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.contract.JMSClientConnector;
+import org.wso2.transport.jms.exception.JMSConnectorException;
+import org.wso2.transport.jms.impl.JMSConnectorFactoryImpl;
+import org.wso2.transport.jms.sender.wrappers.SessionWrapper;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.Map;
 import java.util.UUID;

--- a/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/CreateBytesMessage.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/CreateBytesMessage.java
@@ -32,9 +32,9 @@ import org.ballerinalang.net.jms.JMSUtils;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.transport.jms.exception.JMSConnectorException;
-import org.wso2.carbon.transport.jms.impl.JMSConnectorFactoryImpl;
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.exception.JMSConnectorException;
+import org.wso2.transport.jms.impl.JMSConnectorFactoryImpl;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.Map;
 import javax.jms.Message;

--- a/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/CreateTextMessage.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/CreateTextMessage.java
@@ -32,9 +32,9 @@ import org.ballerinalang.net.jms.JMSUtils;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.transport.jms.exception.JMSConnectorException;
-import org.wso2.carbon.transport.jms.impl.JMSConnectorFactoryImpl;
-import org.wso2.carbon.transport.jms.utils.JMSConstants;
+import org.wso2.transport.jms.exception.JMSConnectorException;
+import org.wso2.transport.jms.impl.JMSConnectorFactoryImpl;
+import org.wso2.transport.jms.utils.JMSConstants;
 
 import java.util.Map;
 import javax.jms.Message;

--- a/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetCorrelationIDHeader.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetCorrelationIDHeader.java
@@ -34,7 +34,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 
 /**
- * Native function to set CorrelationID header to carbon message.
+ * Native function to set CorrelationID header to message.
  */
 
 @BallerinaFunction(

--- a/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetTypeHeader.java
+++ b/component/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetTypeHeader.java
@@ -34,7 +34,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 
 /**
- * Native function to set Type header to carbon message.
+ * Native function to set Type header to message.
  */
 
 @BallerinaFunction(

--- a/component/src/test/java/org/ballerinalang/net/jms/nativeimpl/util/TestAcknowledgementCallback.java
+++ b/component/src/test/java/org/ballerinalang/net/jms/nativeimpl/util/TestAcknowledgementCallback.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.net.jms.nativeimpl.util;
 
-import org.wso2.carbon.transport.jms.callback.JMSCallback;
+import org.wso2.transport.jms.callback.JMSCallback;
 
 import javax.jms.Session;
 

--- a/component/src/test/java/org/ballerinalang/net/jms/nativeimpl/util/TestTransactionCallback.java
+++ b/component/src/test/java/org/ballerinalang/net/jms/nativeimpl/util/TestTransactionCallback.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.net.jms.nativeimpl.util;
 
-import org.wso2.carbon.transport.jms.callback.JMSCallback;
+import org.wso2.transport.jms.callback.JMSCallback;
 
 import javax.jms.Session;
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
                 <version>${javax.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.transport</groupId>
-                <artifactId>org.wso2.carbon.transport.jms</artifactId>
-                <version>${carbon.transport.version}</version>
+                <groupId>org.wso2.transport.jms</groupId>
+                <artifactId>transport-jms</artifactId>
+                <version>${wso2.transport.jms.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
@@ -259,7 +259,7 @@
     <properties>
         <project.scm.id>my-scm-server</project.scm.id>
         <ballerina.version>0.95.0</ballerina.version>
-        <carbon.transport.version>6.0.41</carbon.transport.version>
+        <wso2.transport.jms.version>6.0.48</wso2.transport.jms.version>
         <javax.jms.version>2.0.1</javax.jms.version>
         <org.testng.version>6.11</org.testng.version>
         <apache.commons-pool2.version>2.4.2</apache.commons-pool2.version>


### PR DESCRIPTION
## Purpose
> JMS transport has been separated out into a new repo transport-jms. That update came with several API changes as well.
> Creating the .zip archive of the packaged connector has been moved into verify phase so that it will be packaged connector will be installed into the .m2